### PR TITLE
Fix sidebar logic

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ import ReportDetails from "./components/testreports/reportdetails/ReportDetails"
 import UploadReport from "./components/testreports/uploadreport/UploadReport";
 import PerformanceTests from "./components/perfomance/PerformanceTests";
 import UpdateReport from "./components/testreports/updatereport/UpdateReport";
+import Home from "./components/testreports/home/Home";
 
 
 class App extends Component {
@@ -35,14 +36,14 @@ class App extends Component {
             <SidePanel/>
             <Switch>
               <Route exact path='/login' component={Login}/>
+              <Route exact path='/' component={Home}/>
+
               <Route exact path='/upload-report' component={UploadReport}/>
 
-              {/*we'll have a proper home screen later on. for now, redirect to loans page*/}
               <Route exact path='/completed/:service' component={CompletedSpockTests}/>
               <Route exact path='/completed/update-report/:id' component={UpdateReport}/>
               <Route exact path='/completed/report/:id' component ={ReportDetails}/>
 
-              <Route exact path='/' component={SpockTestsInDevelopment}/>
               <Route exact path='/development/:service' component={SpockTestsInDevelopment}/>
               {/*<Route exact path='/report/development/:id'*/}
                      {/*render={(props) => <ReportDetails {...props} collectionUrl='developmentreports' />}/>*/}

--- a/src/App.js
+++ b/src/App.js
@@ -38,13 +38,12 @@ class App extends Component {
               <Route exact path='/upload-report' component={UploadReport}/>
 
               {/*we'll have a proper home screen later on. for now, redirect to loans page*/}
-              <Route exact path='/completed' component={CompletedSpockTests}/>
-              <Route exact path='/completed/loans' component={CompletedSpockTests}/>
+              <Route exact path='/completed/:service' component={CompletedSpockTests}/>
               <Route exact path='/completed/update-report/:id' component={UpdateReport}/>
               <Route exact path='/completed/report/:id' component ={ReportDetails}/>
 
               <Route exact path='/' component={SpockTestsInDevelopment}/>
-              <Route exact path='/development' component={SpockTestsInDevelopment}/>
+              <Route exact path='/development/:service' component={SpockTestsInDevelopment}/>
               {/*<Route exact path='/report/development/:id'*/}
                      {/*render={(props) => <ReportDetails {...props} collectionUrl='developmentreports' />}/>*/}
               <Route exact path='/development/report/:id' component ={ReportDetails}/>

--- a/src/App.js
+++ b/src/App.js
@@ -38,11 +38,12 @@ class App extends Component {
               <Route exact path='/upload-report' component={UploadReport}/>
 
               {/*we'll have a proper home screen later on. for now, redirect to loans page*/}
-              <Route exact path='/' component={CompletedSpockTests}/>
+              <Route exact path='/completed' component={CompletedSpockTests}/>
               <Route exact path='/completed/loans' component={CompletedSpockTests}/>
               <Route exact path='/completed/update-report/:id' component={UpdateReport}/>
               <Route exact path='/completed/report/:id' component ={ReportDetails}/>
 
+              <Route exact path='/' component={SpockTestsInDevelopment}/>
               <Route exact path='/development' component={SpockTestsInDevelopment}/>
               {/*<Route exact path='/report/development/:id'*/}
                      {/*render={(props) => <ReportDetails {...props} collectionUrl='developmentreports' />}/>*/}

--- a/src/app.css
+++ b/src/app.css
@@ -51,7 +51,7 @@ body{
 #reports-section{
     width: 40%;
     position: relative;
-    margin: 125px auto 0 auto;
+    margin: 0 auto 0 auto;
     transition: all ease-in-out 400ms;
 }
 

--- a/src/components/navigation/navigation.css
+++ b/src/components/navigation/navigation.css
@@ -1,13 +1,14 @@
 #navigation-top{
     padding: 20px;
     height: 30px;
-    position: fixed;
+    /*position: fixed;*/
     background: #01ACC1;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
     width: 100%;
     color: white;
     z-index: 1;
     top: 0;
+    margin-bottom: 20px;
     text-align: center;
     transition: all ease-in-out 400ms;
 }

--- a/src/components/sidepanel/Links.js
+++ b/src/components/sidepanel/Links.js
@@ -1,44 +1,61 @@
-import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
+import React, {Component} from 'react';
+import {Link} from 'react-router-dom';
 
-export default class Links  extends Component{
-    constructor(props){
-        super(props);
-        this.state = {
-            expand: '+',
-            expanded: false
-        }
+export default class Links extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      expandIcon: '+',
+      isExpanded: false,
+      // style: {fontWeight: "700", textDecoration: "underline"}
+      style: {fontWeight: '100', textDecoration: 'none'}
     }
-    render(){
-        return(
-            <div id={this.props.active ? 'active' : 'link'}>
-                <Link to={this.props.whereto}>
-                  <span id='report_navigation_title'><img id='link-img' src={this.props.icon} alt={this.props.title}></img>{this.props.title}</span>
-                </Link>
-                
-                <span id='expand' onClick={
-                    () => {
-                        this.state.expand === '+' ? 
-                        this.setState({expand: '-', expanded: true}) : this.setState({expand: '+', expanded: false})
-                    }
-                }>
-                  {this.props.haslinks && this.props.isHovered ? this.state.expand : null}
+  }
+
+  handleClick = (e) => {
+    this.setState({
+      [e.target.name]: e.target.value
+    });
+  };
+
+  render() {
+    const { style } = this.state;
+
+    return (
+        <div id={this.props.active ? 'active' : 'link'}>
+          <Link to={this.props.titleLink}>
+            <span id='report_navigation_title'>
+              <img id='link-img' src={this.props.icon} alt={this.props.title}></img>{this.props.title}</span>
+          </Link>
+
+          <span id='expandIcon' onClick={
+            () => {
+              this.state.expandIcon === '+' ?
+                  this.setState({expandIcon: '-', isExpanded: true}) : this.setState(
+                  {expandIcon: '+', isExpanded: false})
+            }
+          }>
+                  {this.props.haslinks && this.props.isHovered
+                      ? this.state.expandIcon : null}
                   </span>
 
-                {
-                    this.props.haslinks ?
-                        <div id={this.state.expanded && this.props.isHovered ? 'mini-links' : 'no_links_display'}>
-                        <ul>
-                            {this.props.links.map((link, index) => {
-                                return (
-                                    <li key={index} style={{fontWeight: link[1] ? "700" : "100", textDecoration: link[1] ? "underline" : "none"}}>{link[0]}</li>
-                                )
-                            })}
-                        </ul>
-                    </div> : null
-                }
-            </div>
-        )
-    }
+          {
+            this.props.haslinks ?
+                <div id={this.state.isExpanded && this.props.isHovered
+                    ? 'mini-links' : 'no_links_display'}>
+                  <ul>
+                    {this.props.links.map((link, index) => {
+                      return (
+                          <Link to={`/development/${link}`} key={index}>
+                            <li style={style[index]} onClick={this.handleClick}>{link}</li>
+                          </Link>
 
+                      )
+                    })}
+                  </ul>
+                </div> : null
+          }
+        </div>
+    )
+  }
 }

--- a/src/components/sidepanel/Links.js
+++ b/src/components/sidepanel/Links.js
@@ -2,24 +2,19 @@ import React, {Component} from 'react';
 import {Link} from 'react-router-dom';
 
 export default class Links extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
+    state = {
       expandIcon: '+',
-      isExpanded: false,
-      // style: {fontWeight: "700", textDecoration: "underline"}
-      style: {fontWeight: '100', textDecoration: 'none'}
-    }
-  }
+      isExpanded: false
+    };
 
-  handleClick = (e) => {
+  handleClick = (index) => {
     this.setState({
-      [e.target.name]: e.target.value
+      activeLinkIndex: index
     });
   };
 
   render() {
-    const { style } = this.state;
+    const { activeLinkIndex } = this.state;
 
     return (
         <div id={this.props.active ? 'active' : 'link'}>
@@ -35,19 +30,22 @@ export default class Links extends Component {
                   {expandIcon: '+', isExpanded: false})
             }
           }>
-                  {this.props.haslinks && this.props.isHovered
+                  {this.props.haslinks && this.props.isExpanded
                       ? this.state.expandIcon : null}
                   </span>
 
           {
             this.props.haslinks ?
-                <div id={this.state.isExpanded && this.props.isHovered
+                <div id={this.state.isExpanded && this.props.isExpanded
                     ? 'mini-links' : 'no_links_display'}>
                   <ul>
                     {this.props.links.map((link, index) => {
                       return (
-                          <Link to={`/development/${link}`} key={index}>
-                            <li style={style[index]} onClick={this.handleClick}>{link}</li>
+                          <Link to={link[1]} key={index}>
+                            <li
+                                onClick={() => this.handleClick(index)}
+                                style={ index === activeLinkIndex ? {fontWeight: '700', textDecoration: 'underline'} : null}
+                            >{link[0]}</li>
                           </Link>
 
                       )

--- a/src/components/sidepanel/Sidepanel.js
+++ b/src/components/sidepanel/Sidepanel.js
@@ -14,8 +14,8 @@ export default class SidePanel extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      firstActive: window.location.pathname === '/' || '/development/:service' ? true : false,
-      secondActive: window.location.pathname === '/completed/:service' ? true : false,
+      firstActive: window.location.pathname === '/' || '/development/' ? true : false,
+      secondActive: window.location.pathname.includes('completed') ? true : false,
       thirdActive: window.location.pathname === '/performance' ? true : false,
       fourthActive: window.location.pathname === '/tasks' ? true : false,
       showCollapsedMenu: true,

--- a/src/components/sidepanel/Sidepanel.js
+++ b/src/components/sidepanel/Sidepanel.js
@@ -14,8 +14,8 @@ export default class SidePanel extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      firstActive: window.location.pathname === '/development' ? true : false,
-      secondActive: window.location.pathname === '/' ? true : false,
+      firstActive: window.location.pathname === '/' || '/development/:service' ? true : false,
+      secondActive: window.location.pathname === '/completed/:service' ? true : false,
       thirdActive: window.location.pathname === '/performance' ? true : false,
       fourthActive: window.location.pathname === '/tasks' ? true : false,
       showCollapsedMenu: true,
@@ -81,7 +81,7 @@ export default class SidePanel extends Component {
               }}>
 
                 <div onClick={this.setFirstActive}>
-                  <Link to='/development'>
+                  <Link to='/'>
                     <Links
                         title={this.state.expanded ? 'Spock Tests In Development'
                             : ''}
@@ -93,13 +93,13 @@ export default class SidePanel extends Component {
                           [ "Rails", '/development/rails']
                         ]}
                         active={this.state.firstActive}
-                        titleLink={'/development'}
+                        titleLink={'/'}
                     />
                   </Link>
                 </div>
 
                 <div onClick={this.setSecondActive}>
-                  <Link to='/completed'>
+                  <Link to='/completed/loans'>
                     <Links
                         title={this.state.expanded ? 'Completed Spock Tests'
                             : ''}
@@ -111,7 +111,7 @@ export default class SidePanel extends Component {
                             ["Loans", '/completed/loans'],
                           [ "Rails", '/completed/rails']
                           ]}
-                        titleLink={'/completed'}
+                        titleLink={'/completed/loans'}
                     />
                   </Link>
                 </div>

--- a/src/components/sidepanel/Sidepanel.js
+++ b/src/components/sidepanel/Sidepanel.js
@@ -18,10 +18,11 @@ export default class SidePanel extends Component {
       secondActive: window.location.pathname === '/' ? true : false,
       thirdActive: window.location.pathname === '/performance' ? true : false,
       fourthActive: window.location.pathname === '/tasks' ? true : false,
-      showMenu: false,
-      showDesktopMenu: true,
-      isHoveredMobile: true,
-      hovered: true
+      showCollapsedMenu: true,
+      expanded: true,
+
+      showMenuMobile: false,
+      isExpandedMobile: true
     };
 
     this.setFirstActive = this.setFirstActive.bind(this);
@@ -35,7 +36,7 @@ export default class SidePanel extends Component {
     this.setState({secondActive: false});
     this.setState({thirdActive: false});
     this.setState({fourthActive: false});
-    this.setState({showMenu: false});
+    this.setState({showMenuMobile: false});
   };
 
   setSecondActive = () => {
@@ -43,7 +44,7 @@ export default class SidePanel extends Component {
     this.setState({secondActive: true});
     this.setState({thirdActive: false});
     this.setState({fourthActive: false});
-    this.setState({showMenu: false});
+    this.setState({showMenuMobile: false});
   };
 
   setThirdActive = () => {
@@ -51,7 +52,7 @@ export default class SidePanel extends Component {
     this.setState({secondActive: false});
     this.setState({thirdActive: true});
     this.setState({fourthActive: false});
-    this.setState({showMenu: false});
+    this.setState({showMenuMobile: false});
   };
 
   setFourthActive = () => {
@@ -59,7 +60,7 @@ export default class SidePanel extends Component {
     this.setState({secondActive: false});
     this.setState({thirdActive: false});
     this.setState({fourthActive: true});
-    this.setState({showMenu: false});
+    this.setState({showMenuMobile: false});
   };
 
   render() {
@@ -68,30 +69,28 @@ export default class SidePanel extends Component {
           {
             <React.Fragment>
               <div id='expand-icon' onClick={() => {
-                this.state.showDesktopMenu ?
-                    this.setState({showDesktopMenu: false, hovered: false}) :
-                    this.setState({showDesktopMenu: true, hovered: true})
+                this.state.showCollapsedMenu ?
+                    this.setState({showCollapsedMenu: false, expanded: false}) :
+                    this.setState({showCollapsedMenu: true, expanded: true})
               }
-              }> {this.state.showDesktopMenu ? 'x' : <img id='menu_bar' src={menu} alt='menu bar'></img>}
+              }> {this.state.showCollapsedMenu ? 'x' : <img id='menu_bar' src={menu} alt='menu bar'></img>}
               </div>
               <div id='sidepanel' style={{
-                width: this.state.hovered ? '21%' : '55px',
+                width: this.state.expanded ? '21%' : '55px',
                 transition: 'all ease-in-out 200ms'
               }}>
 
                 <div onClick={this.setFirstActive}>
                   <Link to='/development'>
                     <Links
-                        title={this.state.hovered ? 'Spock Tests In Development'
+                        title={this.state.expanded ? 'Spock Tests In Development'
                             : ''}
-                        isHovered={this.state.hovered}
+                        isHovered={this.state.expanded}
                         icon={report}
                         haslinks={true}
-                        links={[['Loans', this.state.firstActive],
-                          ['Rails', null], ['Users', null], ['Auth', null],
-                          ['Surveys', null]]}
+                        links={['Loans','Rails','Users','Auth','Surveys']}
                         active={this.state.firstActive}
-                        whereto={'/development'}
+                        titleLink={'/development'}
                     />
                   </Link>
                 </div>
@@ -99,16 +98,14 @@ export default class SidePanel extends Component {
                 <div onClick={this.setSecondActive}>
                   <Link to='/completed'>
                     <Links
-                        title={this.state.hovered ? 'Completed Spock Tests'
+                        title={this.state.expanded ? 'Completed Spock Tests'
                             : ''}
-                        isHovered={this.state.hovered}
+                        isHovered={this.state.expanded}
                         haslinks={true}
                         icon={dev}
                         active={this.state.secondActive}
-                        links={[['Loans', this.state.secondActive],
-                          ['Rails', null], ['Users', null], ['Auth', null],
-                          ['Surveys', null]]}
-                        whereto={'/completed'}
+                        links={['Loans','Rails','Users','Auth','Surveys']}
+                        titleLink={'/completed'}
                     />
                   </Link>
                 </div>
@@ -116,13 +113,13 @@ export default class SidePanel extends Component {
                 <div onClick={this.setThirdActive}>
                   <Link to='/performance'>
                     <Links
-                        title={this.state.hovered ? 'Performance Tests' : ''}
-                        isHovered={this.state.hovered}
+                        title={this.state.expanded ? 'Performance Tests' : ''}
+                        isHovered={this.state.expanded}
                         haslinks={false}
                         icon={perf}
                         active={this.state.thirdActive}
                         links={[]}
-                        whereto={'/performance'}
+                        titleLink={'/performance'}
                     />
                   </Link>
                 </div>
@@ -130,80 +127,80 @@ export default class SidePanel extends Component {
                 <div onClick={this.setFourthActive}>
                   <Link to='/tasks'>
                     <Links
-                        title={this.state.hovered ? 'Tasks' : ''}
-                        isHovered={this.state.hovered}
+                        title={this.state.expanded ? 'Tasks' : ''}
+                        isHovered={this.state.expanded}
                         haslinks={false}
                         icon={task}
                         active={this.state.thirdActive}
                         links={[]}
-                        whereto={'/tasks'}
+                        titleLink={'/tasks'}
                     />
                   </Link>
                 </div>
               </div>
 
               <div id='sidepanel-mobile'
-                   style={{display: this.state.showMenu ? 'block' : 'none'}}>
+                   style={{display: this.state.showMenuMobile ? 'block' : 'none'}}>
                 <div onClick={this.setFirstActive}>
                   <Links
                       title='Spock Reports'
-                      isHovered={this.state.isHoveredMobile}
+                      isHovered={this.state.isExpandedMobile}
                       haslinks={true}
                       icon={report}
                       links={[['Loans', this.state.firstActive],
                         ['Rails', null], ['Users', null], ['Auth', null],
                         ['Surveys', null]]}
                       active={this.state.firstActive}
-                      whereto={'/'}
+                      titleLink={'/'}
                   />
                 </div>
 
                 <div onClick={this.setSecondActive}>
                   <Links
                       title='Development'
-                      isHovered={this.state.isHoveredMobile}
+                      isHovered={this.state.isExpandedMobile}
                       haslinks={true}
                       icon={dev}
                       active={this.state.secondActive}
                       links={[['Loans', this.state.secondActive],
                         ['Rails', null], ['Users', null], ['Auth', null],
                         ['Surveys', null]]}
-                      whereto={'/development'}
+                      titleLink={'/development'}
                   />
                 </div>
 
                 <div onClick={this.setThirdActive}>
                   <Links
                       title='Performance Tests'
-                      isHovered={this.state.isHoveredMobile}
+                      isHovered={this.state.isExpandedMobile}
                       haslinks={false}
                       icon={perf}
                       active={this.state.thirdActive}
                       links={[]}
-                      whereto={'/performance'}
+                      titleLink={'/performance'}
                   />
                 </div>
 
                 <div onClick={this.setFourthActive}>
                   <Links
                       title='Tasks'
-                      isHovered={this.state.isHoveredMobile}
+                      isHovered={this.state.isExpandedMobile}
                       haslinks={false}
                       icon={task}
                       active={this.state.fourthActive}
                       links={[]}
-                      whereto={'/tasks'}
+                      titleLink={'/tasks'}
                   />
                 </div>
 
               </div>
 
               <div id='mobile-expand-icon' onClick={() => {
-                this.state.showMenu ?
-                    this.setState({showMenu: false}) :
-                    this.setState({showMenu: true})
+                this.state.showMenuMobile ?
+                    this.setState({showMenuMobile: false}) :
+                    this.setState({showMenuMobile: true})
               }
-              }> {this.state.showMenu ? 'x' : <img id='menu_bar' src={menu} alt='menu bar'></img>}
+              }> {this.state.showMenuMobile ? 'x' : <img id='menu_bar' src={menu} alt='menu bar'></img>}
               </div>
             </React.Fragment>
 

--- a/src/components/sidepanel/Sidepanel.js
+++ b/src/components/sidepanel/Sidepanel.js
@@ -14,10 +14,10 @@ export default class SidePanel extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      firstActive: window.location.pathname === '/' || '/development/' ? true : false,
-      secondActive: window.location.pathname.includes('completed') ? true : false,
-      thirdActive: window.location.pathname === '/performance' ? true : false,
-      fourthActive: window.location.pathname === '/tasks' ? true : false,
+      firstActive: window.location.pathname.includes('development') || window.location.pathname ===('/'),
+      secondActive: window.location.pathname.includes('completed'),
+      thirdActive: window.location.pathname === '/performance',
+      fourthActive: window.location.pathname === '/tasks',
       showCollapsedMenu: true,
       expanded: true,
 
@@ -137,7 +137,7 @@ export default class SidePanel extends Component {
                         isExpanded={this.state.expanded}
                         haslinks={false}
                         icon={task}
-                        active={this.state.thirdActive}
+                        active={this.state.fourthActive}
                         links={[]}
                         titleLink={'/tasks'}
                     />
@@ -145,69 +145,69 @@ export default class SidePanel extends Component {
                 </div>
               </div>
 
-              <div id='sidepanel-mobile'
-                   style={{display: this.state.showMenuMobile ? 'block' : 'none'}}>
-                <div onClick={this.setFirstActive}>
-                  <Links
-                      title='Spock Reports'
-                      isExpanded={this.state.isExpandedMobile}
-                      haslinks={true}
-                      icon={report}
-                      links={[['Loans', this.state.firstActive],
-                        ['Rails', null], ['Users', null], ['Auth', null],
-                        ['Surveys', null]]}
-                      active={this.state.firstActive}
-                      titleLink={'/'}
-                  />
-                </div>
+              {/*<div id='sidepanel-mobile'*/}
+                   {/*style={{display: this.state.showMenuMobile ? 'block' : 'none'}}>*/}
+                {/*<div onClick={this.setFirstActive}>*/}
+                  {/*<Links*/}
+                      {/*title='Spock Reports'*/}
+                      {/*isExpanded={this.state.isExpandedMobile}*/}
+                      {/*haslinks={true}*/}
+                      {/*icon={report}*/}
+                      {/*links={[['Loans', this.state.firstActive],*/}
+                        {/*['Rails', null], ['Users', null], ['Auth', null],*/}
+                        {/*['Surveys', null]]}*/}
+                      {/*active={this.state.firstActive}*/}
+                      {/*titleLink={'/'}*/}
+                  {/*/>*/}
+                {/*</div>*/}
 
-                <div onClick={this.setSecondActive}>
-                  <Links
-                      title='Development'
-                      isExpanded={this.state.isExpandedMobile}
-                      haslinks={true}
-                      icon={dev}
-                      active={this.state.secondActive}
-                      links={[['Loans', this.state.secondActive],
-                        ['Rails', null], ['Users', null], ['Auth', null],
-                        ['Surveys', null]]}
-                      titleLink={'/development'}
-                  />
-                </div>
+                {/*<div onClick={this.setSecondActive}>*/}
+                  {/*<Links*/}
+                      {/*title='Development'*/}
+                      {/*isExpanded={this.state.isExpandedMobile}*/}
+                      {/*haslinks={true}*/}
+                      {/*icon={dev}*/}
+                      {/*active={this.state.secondActive}*/}
+                      {/*links={[['Loans', this.state.secondActive],*/}
+                        {/*['Rails', null], ['Users', null], ['Auth', null],*/}
+                        {/*['Surveys', null]]}*/}
+                      {/*titleLink={'/development'}*/}
+                  {/*/>*/}
+                {/*</div>*/}
 
-                <div onClick={this.setThirdActive}>
-                  <Links
-                      title='Performance Tests'
-                      isExpanded={this.state.isExpandedMobile}
-                      haslinks={false}
-                      icon={perf}
-                      active={this.state.thirdActive}
-                      links={[]}
-                      titleLink={'/performance'}
-                  />
-                </div>
+                {/*<div onClick={this.setThirdActive}>*/}
+                  {/*<Links*/}
+                      {/*title='Performance Tests'*/}
+                      {/*isExpanded={this.state.isExpandedMobile}*/}
+                      {/*haslinks={false}*/}
+                      {/*icon={perf}*/}
+                      {/*active={this.state.thirdActive}*/}
+                      {/*links={[]}*/}
+                      {/*titleLink={'/performance'}*/}
+                  {/*/>*/}
+                {/*</div>*/}
 
-                <div onClick={this.setFourthActive}>
-                  <Links
-                      title='Tasks'
-                      isExpanded={this.state.isExpandedMobile}
-                      haslinks={false}
-                      icon={task}
-                      active={this.state.fourthActive}
-                      links={[]}
-                      titleLink={'/tasks'}
-                  />
-                </div>
+                {/*<div onClick={this.setFourthActive}>*/}
+                  {/*<Links*/}
+                      {/*title='Tasks'*/}
+                      {/*isExpanded={this.state.isExpandedMobile}*/}
+                      {/*haslinks={false}*/}
+                      {/*icon={task}*/}
+                      {/*active={this.state.fourthActive}*/}
+                      {/*links={[]}*/}
+                      {/*titleLink={'/tasks'}*/}
+                  {/*/>*/}
+                {/*</div>*/}
 
-              </div>
+              {/*</div>*/}
 
-              <div id='mobile-expand-icon' onClick={() => {
-                this.state.showMenuMobile ?
-                    this.setState({showMenuMobile: false}) :
-                    this.setState({showMenuMobile: true})
-              }
-              }> {this.state.showMenuMobile ? 'x' : <img id='menu_bar' src={menu} alt='menu bar'></img>}
-              </div>
+              {/*<div id='mobile-expand-icon' onClick={() => {*/}
+                {/*this.state.showMenuMobile ?*/}
+                    {/*this.setState({showMenuMobile: false}) :*/}
+                    {/*this.setState({showMenuMobile: true})*/}
+              {/*}*/}
+              {/*}> {this.state.showMenuMobile ? 'x' : <img id='menu_bar' src={menu} alt='menu bar'></img>}*/}
+              {/*</div>*/}
             </React.Fragment>
 
           }

--- a/src/components/sidepanel/Sidepanel.js
+++ b/src/components/sidepanel/Sidepanel.js
@@ -85,7 +85,7 @@ export default class SidePanel extends Component {
                     <Links
                         title={this.state.expanded ? 'Spock Tests In Development'
                             : ''}
-                        isHovered={this.state.expanded}
+                        isExpanded={this.state.expanded}
                         icon={report}
                         haslinks={true}
                         links={['Loans','Rails','Users','Auth','Surveys']}
@@ -100,11 +100,14 @@ export default class SidePanel extends Component {
                     <Links
                         title={this.state.expanded ? 'Completed Spock Tests'
                             : ''}
-                        isHovered={this.state.expanded}
+                        isExpanded={this.state.expanded}
                         haslinks={true}
                         icon={dev}
                         active={this.state.secondActive}
-                        links={['Loans','Rails','Users','Auth','Surveys']}
+                        links={[
+                            ["Loans", '/completed/loans'],
+                          [ "Rails", '/completed/rails']
+                          ]}
                         titleLink={'/completed'}
                     />
                   </Link>
@@ -114,7 +117,7 @@ export default class SidePanel extends Component {
                   <Link to='/performance'>
                     <Links
                         title={this.state.expanded ? 'Performance Tests' : ''}
-                        isHovered={this.state.expanded}
+                        isExpanded={this.state.expanded}
                         haslinks={false}
                         icon={perf}
                         active={this.state.thirdActive}
@@ -128,7 +131,7 @@ export default class SidePanel extends Component {
                   <Link to='/tasks'>
                     <Links
                         title={this.state.expanded ? 'Tasks' : ''}
-                        isHovered={this.state.expanded}
+                        isExpanded={this.state.expanded}
                         haslinks={false}
                         icon={task}
                         active={this.state.thirdActive}
@@ -144,7 +147,7 @@ export default class SidePanel extends Component {
                 <div onClick={this.setFirstActive}>
                   <Links
                       title='Spock Reports'
-                      isHovered={this.state.isExpandedMobile}
+                      isExpanded={this.state.isExpandedMobile}
                       haslinks={true}
                       icon={report}
                       links={[['Loans', this.state.firstActive],
@@ -158,7 +161,7 @@ export default class SidePanel extends Component {
                 <div onClick={this.setSecondActive}>
                   <Links
                       title='Development'
-                      isHovered={this.state.isExpandedMobile}
+                      isExpanded={this.state.isExpandedMobile}
                       haslinks={true}
                       icon={dev}
                       active={this.state.secondActive}
@@ -172,7 +175,7 @@ export default class SidePanel extends Component {
                 <div onClick={this.setThirdActive}>
                   <Links
                       title='Performance Tests'
-                      isHovered={this.state.isExpandedMobile}
+                      isExpanded={this.state.isExpandedMobile}
                       haslinks={false}
                       icon={perf}
                       active={this.state.thirdActive}
@@ -184,7 +187,7 @@ export default class SidePanel extends Component {
                 <div onClick={this.setFourthActive}>
                   <Links
                       title='Tasks'
-                      isHovered={this.state.isExpandedMobile}
+                      isExpanded={this.state.isExpandedMobile}
                       haslinks={false}
                       icon={task}
                       active={this.state.fourthActive}

--- a/src/components/sidepanel/Sidepanel.js
+++ b/src/components/sidepanel/Sidepanel.js
@@ -90,7 +90,21 @@ export default class SidePanel extends Component {
                         haslinks={true}
                         links={[
                           ["Loans", '/development/loans'],
-                          [ "Rails", '/development/rails']
+                          [ "Users", '/development/users'],
+                          [ "Surveys", '/development/surveys'],
+                          [ "Auth", '/development/auth'],
+                          [ "Rails", '/development/rails'],
+                          [ "Comms", '/development/comms'],
+                          [ "Approval", '/development/approval'],
+                          [ "Scheduler", '/development/scheduler'],
+                          [ "DsRouter", '/development/dsrouter'],
+                          [ "Rules", '/development/rules'],
+                          [ "Assignment", '/development/assignment'],
+                          [ "Dss", '/development/dss'],
+                          [ "Kyc", '/development/kyc'],
+                          [ "Attribution", '/development/attribution'],
+                          [ "Settlement", '/development/settlement'],
+                          [ "Verification", '/development/verification']
                         ]}
                         active={this.state.firstActive}
                         titleLink={'/'}
@@ -108,8 +122,22 @@ export default class SidePanel extends Component {
                         icon={dev}
                         active={this.state.secondActive}
                         links={[
-                            ["Loans", '/completed/loans'],
-                          [ "Rails", '/completed/rails']
+                          ["Loans", '/completed/loans'],
+                          [ "Users", '/completed/users'],
+                          [ "Surveys", '/completed/surveys'],
+                          [ "Auth", '/completed/auth'],
+                          [ "Rails", '/completed/rails'],
+                          [ "Comms", '/completed/comms'],
+                          [ "Approval", '/completed/approval'],
+                          [ "Scheduler", '/completed/scheduler'],
+                          [ "DsRouter", '/completed/dsrouter'],
+                          [ "Rules", '/completed/rules'],
+                          [ "Assignment", '/completed/assignment'],
+                          [ "Dss", '/completed/dss'],
+                          [ "Kyc", '/completed/kyc'],
+                          [ "Attribution", '/completed/attribution'],
+                          [ "Settlement", '/completed/settlement'],
+                          [ "Verification", '/completed/verification']
                           ]}
                         titleLink={'/completed/loans'}
                     />

--- a/src/components/sidepanel/Sidepanel.js
+++ b/src/components/sidepanel/Sidepanel.js
@@ -88,7 +88,10 @@ export default class SidePanel extends Component {
                         isExpanded={this.state.expanded}
                         icon={report}
                         haslinks={true}
-                        links={['Loans','Rails','Users','Auth','Surveys']}
+                        links={[
+                          ["Loans", '/development/loans'],
+                          [ "Rails", '/development/rails']
+                        ]}
                         active={this.state.firstActive}
                         titleLink={'/development'}
                     />

--- a/src/components/sidepanel/Sidepanel.js
+++ b/src/components/sidepanel/Sidepanel.js
@@ -173,69 +173,69 @@ export default class SidePanel extends Component {
                 </div>
               </div>
 
-              {/*<div id='sidepanel-mobile'*/}
-                   {/*style={{display: this.state.showMenuMobile ? 'block' : 'none'}}>*/}
-                {/*<div onClick={this.setFirstActive}>*/}
-                  {/*<Links*/}
-                      {/*title='Spock Reports'*/}
-                      {/*isExpanded={this.state.isExpandedMobile}*/}
-                      {/*haslinks={true}*/}
-                      {/*icon={report}*/}
-                      {/*links={[['Loans', this.state.firstActive],*/}
-                        {/*['Rails', null], ['Users', null], ['Auth', null],*/}
-                        {/*['Surveys', null]]}*/}
-                      {/*active={this.state.firstActive}*/}
-                      {/*titleLink={'/'}*/}
-                  {/*/>*/}
-                {/*</div>*/}
+              <div id='sidepanel-mobile'
+                   style={{display: this.state.showMenuMobile ? 'block' : 'none'}}>
+                <div onClick={this.setFirstActive}>
+                  <Links
+                      title='Spock Reports'
+                      isExpanded={this.state.isExpandedMobile}
+                      haslinks={true}
+                      icon={report}
+                      links={[['Loans', this.state.firstActive],
+                        ['Rails', null], ['Users', null], ['Auth', null],
+                        ['Surveys', null]]}
+                      active={this.state.firstActive}
+                      titleLink={'/'}
+                  />
+                </div>
 
-                {/*<div onClick={this.setSecondActive}>*/}
-                  {/*<Links*/}
-                      {/*title='Development'*/}
-                      {/*isExpanded={this.state.isExpandedMobile}*/}
-                      {/*haslinks={true}*/}
-                      {/*icon={dev}*/}
-                      {/*active={this.state.secondActive}*/}
-                      {/*links={[['Loans', this.state.secondActive],*/}
-                        {/*['Rails', null], ['Users', null], ['Auth', null],*/}
-                        {/*['Surveys', null]]}*/}
-                      {/*titleLink={'/development'}*/}
-                  {/*/>*/}
-                {/*</div>*/}
+                <div onClick={this.setSecondActive}>
+                  <Links
+                      title='Development'
+                      isExpanded={this.state.isExpandedMobile}
+                      haslinks={true}
+                      icon={dev}
+                      active={this.state.secondActive}
+                      links={[['Loans', this.state.secondActive],
+                        ['Rails', null], ['Users', null], ['Auth', null],
+                        ['Surveys', null]]}
+                      titleLink={'/development'}
+                  />
+                </div>
 
-                {/*<div onClick={this.setThirdActive}>*/}
-                  {/*<Links*/}
-                      {/*title='Performance Tests'*/}
-                      {/*isExpanded={this.state.isExpandedMobile}*/}
-                      {/*haslinks={false}*/}
-                      {/*icon={perf}*/}
-                      {/*active={this.state.thirdActive}*/}
-                      {/*links={[]}*/}
-                      {/*titleLink={'/performance'}*/}
-                  {/*/>*/}
-                {/*</div>*/}
+                <div onClick={this.setThirdActive}>
+                  <Links
+                      title='Performance Tests'
+                      isExpanded={this.state.isExpandedMobile}
+                      haslinks={false}
+                      icon={perf}
+                      active={this.state.thirdActive}
+                      links={[]}
+                      titleLink={'/performance'}
+                  />
+                </div>
 
-                {/*<div onClick={this.setFourthActive}>*/}
-                  {/*<Links*/}
-                      {/*title='Tasks'*/}
-                      {/*isExpanded={this.state.isExpandedMobile}*/}
-                      {/*haslinks={false}*/}
-                      {/*icon={task}*/}
-                      {/*active={this.state.fourthActive}*/}
-                      {/*links={[]}*/}
-                      {/*titleLink={'/tasks'}*/}
-                  {/*/>*/}
-                {/*</div>*/}
+                <div onClick={this.setFourthActive}>
+                  <Links
+                      title='Tasks'
+                      isExpanded={this.state.isExpandedMobile}
+                      haslinks={false}
+                      icon={task}
+                      active={this.state.fourthActive}
+                      links={[]}
+                      titleLink={'/tasks'}
+                  />
+                </div>
 
-              {/*</div>*/}
+              </div>
 
-              {/*<div id='mobile-expand-icon' onClick={() => {*/}
-                {/*this.state.showMenuMobile ?*/}
-                    {/*this.setState({showMenuMobile: false}) :*/}
-                    {/*this.setState({showMenuMobile: true})*/}
-              {/*}*/}
-              {/*}> {this.state.showMenuMobile ? 'x' : <img id='menu_bar' src={menu} alt='menu bar'></img>}*/}
-              {/*</div>*/}
+              <div id='mobile-expand-icon' onClick={() => {
+                this.state.showMenuMobile ?
+                    this.setState({showMenuMobile: false}) :
+                    this.setState({showMenuMobile: true})
+              }
+              }> {this.state.showMenuMobile ? 'x' : <img id='menu_bar' src={menu} alt='menu bar'></img>}
+              </div>
             </React.Fragment>
 
           }

--- a/src/components/sidepanel/Sidepanel.js
+++ b/src/components/sidepanel/Sidepanel.js
@@ -14,8 +14,8 @@ export default class SidePanel extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      firstActive: window.location.pathname === '/' ? true : false,
-      secondActive: window.location.pathname === '/development' ? true : false,
+      firstActive: window.location.pathname === '/development' ? true : false,
+      secondActive: window.location.pathname === '/' ? true : false,
       thirdActive: window.location.pathname === '/performance' ? true : false,
       fourthActive: window.location.pathname === '/tasks' ? true : false,
       showMenu: false,
@@ -80,9 +80,9 @@ export default class SidePanel extends Component {
               }}>
 
                 <div onClick={this.setFirstActive}>
-                  <Link to='/'>
+                  <Link to='/development'>
                     <Links
-                        title={this.state.hovered ? 'Completed Spock Tests'
+                        title={this.state.hovered ? 'Spock Tests In Development'
                             : ''}
                         isHovered={this.state.hovered}
                         icon={report}
@@ -91,15 +91,15 @@ export default class SidePanel extends Component {
                           ['Rails', null], ['Users', null], ['Auth', null],
                           ['Surveys', null]]}
                         active={this.state.firstActive}
-                        whereto={'/'}
+                        whereto={'/development'}
                     />
                   </Link>
                 </div>
 
                 <div onClick={this.setSecondActive}>
-                  <Link to='/development'>
+                  <Link to='/completed'>
                     <Links
-                        title={this.state.hovered ? 'Spock Tests In Development'
+                        title={this.state.hovered ? 'Completed Spock Tests'
                             : ''}
                         isHovered={this.state.hovered}
                         haslinks={true}
@@ -108,7 +108,7 @@ export default class SidePanel extends Component {
                         links={[['Loans', this.state.secondActive],
                           ['Rails', null], ['Users', null], ['Auth', null],
                           ['Surveys', null]]}
-                        whereto={'/development'}
+                        whereto={'/completed'}
                     />
                   </Link>
                 </div>

--- a/src/components/tasks/tasks.css
+++ b/src/components/tasks/tasks.css
@@ -1,7 +1,7 @@
 #tasks-section{
     width: 40%;
     position: relative;
-    margin: 125px auto 0 auto;
+    margin: 0 auto 0 auto;
     transition: all ease-in-out 400ms;
 }
 

--- a/src/components/testreports/completedspocktests/CompletedSpockTests.js
+++ b/src/components/testreports/completedspocktests/CompletedSpockTests.js
@@ -91,7 +91,9 @@ const CompletedSpockTests = (props) => {
 
 //todo extract this to StringUtils
 function getServiceNameFromPathName(pathname) {
-  return pathname.split('/completed/')[1]
+  const service = pathname.split('/completed/')[1];
+
+  return service
 }
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/components/testreports/completedspocktests/CompletedSpockTests.js
+++ b/src/components/testreports/completedspocktests/CompletedSpockTests.js
@@ -89,33 +89,44 @@ const CompletedSpockTests = (props) => {
 
 };
 
-const mapStateToProps = (state) => {
+//todo extract this to StringUtils
+function getServiceNameFromPathName(pathname) {
+  return pathname.split('/completed/')[1]
+}
+
+const mapStateToProps = (state, ownProps) => {
   console.log(state);
   return {
     auth: state.firebase.auth,
     featureReports: state.firestore.ordered.featureReports,
     endpointReports: state.firestore.ordered.endpointReports,
+    collection: 'completedreports',
+    service: getServiceNameFromPathName(ownProps.location.pathname)
   }
 };
 
 export default compose(
     connect(mapStateToProps),
-    firestoreConnect([
-      {
-        collection: 'company',
-        doc: 'tala',
-        subcollections: [{ collection: 'completedreports' }],
-        where: ['type', '==', 'feature'],
-        storeAs: 'featureReports'
-      }
-    ]),
-    firestoreConnect([
-      {
-        collection: 'company',
-        doc: 'tala',
-        subcollections: [{ collection: 'completedreports' }],
-        where: ['type', '==', 'endpoint'],
-        storeAs: 'endpointReports'
-      }
-    ])
+    firestoreConnect(props => {
+      return [
+        {
+          collection: 'company',
+          doc: 'tala',
+          subcollections: [{collection: props.collection}],
+          where: ['type', '==', 'feature'],
+          storeAs: 'featureReports'
+        }
+      ]
+    }),
+    firestoreConnect(props => {
+      return [
+        {
+          collection: 'company',
+          doc: 'tala',
+          subcollections: [{collection: 'completedreports'}],
+          where: ['type', '==', 'endpoint'],
+          storeAs: 'endpointReports'
+        }
+      ]
+    })
 )(CompletedSpockTests)

--- a/src/components/testreports/completedspocktests/CompletedSpockTests.js
+++ b/src/components/testreports/completedspocktests/CompletedSpockTests.js
@@ -113,7 +113,10 @@ export default compose(
           collection: 'company',
           doc: 'tala',
           subcollections: [{collection: props.collection}],
-          where: ['type', '==', 'feature'],
+          where: [
+            ['type', '==', 'feature'],
+            ['service', '==', props.service]
+          ],
           storeAs: 'featureReports'
         }
       ]
@@ -123,8 +126,11 @@ export default compose(
         {
           collection: 'company',
           doc: 'tala',
-          subcollections: [{collection: 'completedreports'}],
-          where: ['type', '==', 'endpoint'],
+          subcollections: [{collection: props.collection}],
+          where: [
+            ['type', '==', 'endpoint'],
+            ['service', '==', props.service]
+          ],
           storeAs: 'endpointReports'
         }
       ]

--- a/src/components/testreports/home/Home.js
+++ b/src/components/testreports/home/Home.js
@@ -10,8 +10,15 @@ import {downloadReport} from "../../../store/actions/reportActions";
 import {setPrevUrl} from "../../../store/actions/authActions";
 
 
-const SpockTestsInDevelopment = (props) => {
+const Home = (props) => {
   const { auth, setPrevUrl, reports } = props;
+
+  useEffect(() => {
+    //
+    return function cleanup() {
+      //clean shit up
+    };
+  },[]);
 
   if (!auth.uid) {
     setPrevUrl(props.location.pathname);
@@ -54,19 +61,11 @@ const SpockTestsInDevelopment = (props) => {
   )
 };
 
-//todo extract this to StringUtils
-function getServiceNameFromPathName(pathname) {
-  return pathname.split('/development/')[1]
-}
-
 const mapStateToProps = (state, ownProps) => {
-  console.log('---------------state');
-  console.log(state);
   return {
     auth: state.firebase.auth,
     reports: state.firestore.ordered.reports,
-    collection: 'developmentreports',
-    service: getServiceNameFromPathName(ownProps.location.pathname)
+    collection: 'developmentreports'
   }
 };
 
@@ -79,17 +78,13 @@ const mapDispatchToProps = (dispatch) => {
 export default compose(
     connect(mapStateToProps, mapDispatchToProps),
     firestoreConnect(props => {
-      console.log('---------------props');
-      console.log(props);
       return [
         {
           collection: 'company',
           doc: 'tala',
           subcollections: [{ collection: props.collection }],
-          // subcollections: [{ collection: 'developmentreports' }],
-          where: ['service', '==', props.service],
           storeAs: 'reports'
         }
       ]
     })
-)(SpockTestsInDevelopment)
+)(Home)

--- a/src/components/testreports/reportdetails/reportdetails.css
+++ b/src/components/testreports/reportdetails/reportdetails.css
@@ -1,7 +1,7 @@
 #report-details-section{
     width: 30%;
     position: relative;
-    margin: 125px auto 0 auto;
+    margin: 0 auto 0 auto;
     transition: all ease-in-out 400ms;
 }
 

--- a/src/components/testreports/spocktestsindevelopment/SpockTestsInDevelopment.js
+++ b/src/components/testreports/spocktestsindevelopment/SpockTestsInDevelopment.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useEffect, useState} from 'react'
 import Report from "../Report";
 import {Link} from "react-router-dom";
 import {compose} from "redux";
@@ -12,6 +12,15 @@ import {setPrevUrl} from "../../../store/actions/authActions";
 
 const SpockTestsInDevelopment = (props) => {
   const { auth, setPrevUrl, reports } = props;
+  const [service, setService] = useState('loans');
+
+  useEffect(() => {
+    // props.service = `loans`;
+    return function cleanup() {
+      //clean shit up
+    };
+  },[]);
+
   if (!auth.uid) {
     setPrevUrl(props.location.pathname);
     return <Redirect to='/login' />;
@@ -53,12 +62,19 @@ const SpockTestsInDevelopment = (props) => {
   )
 };
 
-const mapStateToProps = (state) => {
-  // console.log('state in SpockTestsInDevelopment');
-  // console.log(state);
+//todo extract this to StringUtils
+function getServiceNameFromPathName(pathname) {
+  return pathname.split('/development/')[1]
+}
+
+const mapStateToProps = (state, ownProps) => {
+  console.log('---------------state');
+  console.log(state);
   return {
     auth: state.firebase.auth,
-    reports: state.firestore.ordered.developmentreports
+    reports: state.firestore.ordered.reports,
+    collection: 'developmentreports',
+    service: getServiceNameFromPathName(ownProps.location.pathname)
   }
 };
 
@@ -70,12 +86,18 @@ const mapDispatchToProps = (dispatch) => {
 
 export default compose(
     connect(mapStateToProps, mapDispatchToProps),
-    firestoreConnect([
-      {
-        collection: 'company',
-        doc: 'tala',
-        subcollections: [{ collection: 'developmentreports' }],
-        storeAs: 'developmentreports'
-      }
-    ])
+    firestoreConnect(props => {
+      console.log('---------------props');
+      console.log(props);
+      return [
+        {
+          collection: 'company',
+          doc: 'tala',
+          subcollections: [{ collection: props.collection }],
+          // subcollections: [{ collection: 'developmentreports' }],
+          where: ['service', '==', props.service],
+          storeAs: 'reports'
+        }
+      ]
+    })
 )(SpockTestsInDevelopment)

--- a/src/components/testreports/spocktestsindevelopment/SpockTestsInDevelopment.js
+++ b/src/components/testreports/spocktestsindevelopment/SpockTestsInDevelopment.js
@@ -60,8 +60,8 @@ function getServiceNameFromPathName(pathname) {
 }
 
 const mapStateToProps = (state, ownProps) => {
-  console.log('---------------state');
-  console.log(state);
+  // console.log('---------------state');
+  // console.log(state);
   return {
     auth: state.firebase.auth,
     reports: state.firestore.ordered.reports,
@@ -79,14 +79,11 @@ const mapDispatchToProps = (dispatch) => {
 export default compose(
     connect(mapStateToProps, mapDispatchToProps),
     firestoreConnect(props => {
-      console.log('---------------props');
-      console.log(props);
       return [
         {
           collection: 'company',
           doc: 'tala',
-          subcollections: [{ collection: props.collection }],
-          // subcollections: [{ collection: 'developmentreports' }],
+          subcollections: [{collection: props.collection}],
           where: ['service', '==', props.service],
           storeAs: 'reports'
         }

--- a/src/components/testreports/updatereport/UpdateReport.js
+++ b/src/components/testreports/updatereport/UpdateReport.js
@@ -116,12 +116,7 @@ class UpdateReport extends Component {
     this.props.updateReport(id, phase, report);
 
     //todo add a cloud function which deletes the previous report from cloud storage
-
-    if(phase == 'development') {
-      this.props.history.push('/development');
-    } else if(phase == 'completed') {
-      this.props.history.push('/');
-    }
+    this.props.history.push(`/${phase}/${service}`);
   };
 
   render() {

--- a/src/components/testreports/uploadreport/UploadReport.js
+++ b/src/components/testreports/uploadreport/UploadReport.js
@@ -101,12 +101,7 @@ class UploadReport extends Component {
       fileDownLoadUrl
     };
     this.props.createReport(report);
-
-    if (phase == 'development') {
-      this.props.history.push('/development');
-    } else if (phase == 'completed') {
-      this.props.history.push('/');
-    }
+    this.props.history.push(`/${phase}/${service}`);
   };
 
   render() {

--- a/src/components/testreports/uploadreport/upload.css
+++ b/src/components/testreports/uploadreport/upload.css
@@ -1,7 +1,7 @@
 #upload{
     width: 40%;
     position: relative;
-    margin: 125px auto 0 auto;
+    margin: 0 auto 0 auto;
     line-height: 1.8em;
     transition: all ease-in-out 400ms;
 }


### PR DESCRIPTION
- Add support for new services (such as decisioning)
- Update SideBar so that all links work. Now when you click on Rails, you’ll be shown the Rails test reports
- Make Development the first component in the Sidebar
- Delete report cache so that every time report details are loaded, the correct report is shown
- Add home page: shows all test reports currently under development 